### PR TITLE
250 chars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 .DS_Store
+.vs/*

--- a/docs/03_improve_deploy_app/0301.md
+++ b/docs/03_improve_deploy_app/0301.md
@@ -17,6 +17,16 @@ Developers at Munson's Pickles and Preserves like the Team Messaging System in g
 
 In this task, you will modify the application to support 250 characters instead of 200. You will also follow a feature branching strategy and use a pull request to bring your change into the `main` branch. If you wish to complete this task using a Test-Driven Design approach, please read the **Advanced Challenges (optional)** section below before making any changes.
 
+# Improving and Deploying the Application
+
+## Message Length Limit
+
+The message length limit has been updated from 200 characters to 250 characters. This change ensures that users can input longer messages without encountering validation errors.
+
+### Code Changes
+
+In the `Message.cs` file, the `[StringLength]` attribute has been updated to:
+
 1. Create a new GitHub Issue indicating the desired outcome.
 2. Create a new branch in GitHub for your changes.
 3. Fetch changes on your machine and check out the new branch you have created.

--- a/src/Application/src/RazorPagesTestSample/Data/Message.cs
+++ b/src/Application/src/RazorPagesTestSample/Data/Message.cs
@@ -9,7 +9,7 @@ namespace RazorPagesTestSample.Data
 
         [Required]
         [DataType(DataType.Text)]
-        [StringLength(200, ErrorMessage = "There's a 200 character limit on messages. Please shorten your message.")]
+        [StringLength(250, ErrorMessage = "The message cannot exceed 250 characters.")]
         public string Text { get; set; }
     }
     #endregion


### PR DESCRIPTION
This pull request includes changes to update the message length limit in the application from 200 characters to 250 characters. The changes involve both documentation updates and code modifications to reflect the new limit.

### Documentation Updates:

* [`docs/03_improve_deploy_app/0301.md`](diffhunk://#diff-2d8faac0b200398f0cadfc6787a8e0e61c3219992ed89d511bf897b5674b5607R20-R29): Added a section explaining the increase in the message length limit from 200 to 250 characters. This ensures users are informed about the new limit and the rationale behind it.

### Code Changes:

* [`src/Application/src/RazorPagesTestSample/Data/Message.cs`](diffhunk://#diff-3ce635672d23bd9cdaa8656d8d117fc07bbea38b87de905339a765df73f3c450L12-R12): Updated the `[StringLength]` attribute in the `Message` class to allow up to 250 characters and modified the error message accordingly.